### PR TITLE
Remove unused fields for signup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bootstrap-will_paginate'
 #group :development do
 #	gem 'thin'
 #end
-gem 'omniauth-mlh', git: "git@github.com:MLH/omniauth-mlh.git"
+gem 'omniauth-mlh', git: "https://github.com/MLH/omniauth-mlh.git"
 gem 'unicorn'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'unicorn'
 group :test do
 	gem 'shoulda'
 	gem 'factory_girl_rails'
+  gem 'test-unit'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       mime-types
     pg (0.17.1)
     polyglot (0.3.5)
+    power_assert (0.2.4)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -169,6 +170,8 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.2.0)
+    test-unit (3.1.3)
+      power_assert
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -216,6 +219,7 @@ DEPENDENCIES
   shoulda
   simple_form
   state_machine
+  test-unit
   therubyracer
   twitter-bootstrap-rails
   uglifier (>= 1.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: git@github.com:MLH/omniauth-mlh.git
-  revision: 17a8bd7ba251de22bb248d30ec21976000382ae7
+  remote: https://github.com/MLH/omniauth-mlh.git
+  revision: 48661e9c90c738dec858de1d951a60d741619f12
   specs:
-    omniauth-mlh (0.1.0)
+    omniauth-mlh (0.1.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (>= 1.1.1, < 2.0)
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,7 +4,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
      if @user.persisted?
-       @user.confirm! if request.env["omniauth.auth"]["info"]["email"] == @user.email
        sign_in_and_redirect @user, :event => :authentication
        set_flash_message(:notice, :success, :kind => "MLH") if is_navigational_format?
      else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,12 +15,8 @@ class User < ActiveRecord::Base
 
   validates :last_name, presence: true
 
-  validates :profile_name, presence: true,
-                           uniqueness: true,
-                           format: {
-                             with: /^[a-zA-Z0-9_-]+$/,
-                             message: 'Must be formatted correctly.'
-                           }
+  validates :resume, presence: true
+  validates :git_account, presence: true
   
   has_many :activities                          
   has_many :albums
@@ -106,6 +102,9 @@ class User < ActiveRecord::Base
 
         user.uid = session['devise.mlh_data']['uid']
         user.provider = :mlh
+        user.password = Devise.friendly_token[0,20]
+        user.profile_name = "#{data.first_name}#{session['devise.mlh_data']['uid']}"
+        data.special_needs if user.special_needs.blank?
         user.email = data.email if user.email.blank?
         user.first_name = data.first_name if user.first_name.blank?
         user.last_name = data.last_name if user.last_name.blank?
@@ -121,6 +120,7 @@ class User < ActiveRecord::Base
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email
       user.password = Devise.friendly_token[0,20]
+      user.profile_name = "#{auth.info.first_name}#{auth.uid}"
       user.first_name = auth.info.first_name
       user.last_name = auth.info.last_name
       user.school_name = auth.info.school.name

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -30,8 +30,8 @@
       <%= f.input :school_name, input_html: { class: 'form-input', id:"school"} %>
       <%= f.input :school_year, input_html: { class: 'form-input',id:"school" }, :collection => ['Freshman', 'Sophomore', 'Junior', 'Senior', 'Recent Graduate']%>
       <%= f.input :email, input_html: { class: 'form-input', id:"email"} %>
-      <%= f.input :tshirt_size, input_html: { class: 'form-input',id:"name" }, :collection => ['Men\'s Small','Men\'s Medium','Men\'s Large', 'Men\'s XL', 'Women\'s Small', 'Women\'s Medium', 'Women\'s Large', 'Women\'s XL']%>
-      <%= f.input :diet, input_html: { class: 'form-input', id:"diet"}, :collection => ['No', 'Vegetarian', 'Kosher', 'Other'] %>
+      <%= f.input :tshirt_size, input_html: { class: 'form-input',id:"name" }, :collection => ['Unisex - S','Unisex - M','Unisex - L', 'Unisex - XL', 'Women\'s - S', 'Women\'s - M', 'Women\'s - L', 'Women\'s - XL']%>
+      <%= f.input :diet, input_html: { class: 'form-input', id:"diet"} %>
       <%= f.input :special_needs, input_html: { class: 'form-input',id:"name"}%>
       <%= f.input :git_account, input_html: { class: 'form-input', id:"github"} %>
     </fieldset>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,21 +4,7 @@
     <%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), html: { class: 'form-vertical' }) do |f| %>
     <%= devise_error_messages! %>
 
-    <% unless session['devise.mlh_data'].present? %>
-      <%= f.input :first_name, label: false, input_html: { class: 'form-input', id:"name",placeholder: "Enter your first name"} %>
-      <%= f.input :last_name, label: false, input_html: { class: 'form-input', id:"name",placeholder: "Enter your last name"} %>
-      <%= f.input :email,label: false, input_html: { class: 'form-input', id:"email", placeholder:"Enter your email"} %>
-      <%= f.input :school_name,label: false, input_html: { class: 'form-input',id:"name", placeholder:"Enter your school"}%>
-      <%= f.input :tshirt_size,label: false, input_html: { class: 'form-input',id:"name", placeholder:"What is your t-shirt size?"}, :collection => ['Men\'s Small','Men\'s Medium','Men\'s Large', 'Men\'s X-Large', 'Women\'s X-Small', 'Women\'s Small', 'Women\'s Medium', 'Women\'s Large'], prompt: "What is your t-shirt size?"%>
-      <%= f.input :diet,label: false, input_html: { class: 'form-input',id:"name", placeholder:"Do you have any dietary restrictions?"}, :collection => ['No', 'Vegetarian', 'Kosher', 'Other'], prompt: "Do you have any dietary restrictions?"%>
-      <%= f.input :special_needs,label: false, input_html: { class: 'form-input',id:"name", placeholder:"Do you have any special needs?"}, prompt: "Do you have any special needs?"%>
-    <% end %>
-
-    <%= f.input :profile_name,label: false, input_html: { class: 'form-input',id:"name", placeholder:"Create a user name"} %>
-    <%= f.input :school_year,label: false, input_html: { class: 'form-input',id:"name", placeholder:"Enter your school year"}, :collection => ['Freshman', 'Sophomore', 'Junior', 'Senior', 'Recent Graduate'], prompt: "Enter your school year"%>
     <%= f.input :git_account,label: false, input_html: { class: 'form-input',id:"name", placeholder:"Enter your GitHub handle"} %>
-    <%= f.input :password,label: false, input_html: { class: 'form-input', id:"name", placeholder:"Enter your password", autocomplete: 'off' } %>
-    <%= f.input :password_confirmation, label: false, input_html: {class: 'form-input',id:"name", placeholder:"Re-Enter your password", autocomplete: 'off'} %>
     <h4 style="line-height: 130%;">Upload your resume in .pdf, .txt, .doc, or .docx - 1MB max. </h4>
     <%= f.input :resume, as: :file, input_html: {class: 'file_upload'} %>
 
@@ -27,6 +13,4 @@
     <% end %>
   </fieldset>
   <h4 style=" padding-bottom:2em; text-align: center; width: 70%; line-height:150%; margin-left:auto; margin-right:auto;">We are sanctioned by and participate in, <a style="color:#555;"href="https://mlh.io" target="_blank">Major League Hacking</a> (MLH). You authorize us to share certain application/registration information for event administration, ranking, MLH administration, and occasional messages about hackathons in line with the <a style="color: #555;" href="https://mlh.io/privacy" target="_blank">MLH Privacy Policy</a>.</h4>
-
 </div>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,16 +8,16 @@ RCubed::Application.routes.draw do
 
 
   as :user do
-    get '/register', to: 'devise/registrations#new', as: :register
-    get '/login', to: 'devise/sessions#new', as: :login
+    get '/register', to: redirect('/users/auth/mlh'), as: :register
+    get '/login', to: redirect('/users/auth/mlh'), as: :login
     get '/logout', to: 'devise/sessions#destroy', as: :logout
   end
 
   devise_for :users, skip: [:sessions], controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 
   as :user do
-    get "/login" => 'devise/sessions#new', as: :new_user_session
-    post "/login" => 'devise/sessions#create', as: :user_session
+    get "/login" => redirect('/users/auth/mlh'), as: :new_user_session
+    post "/login" => redirect('/users/auth/mlh'), as: :user_session
     delete "/logout" => 'devise/sessions#destroy', as: :destroy_user_session
   end
 


### PR DESCRIPTION
As requested:

> okay, can you set it up so the usernames/schoolyear/passwords on the hackru registration form are gone, and that we only send out a hackru confirmation email if they provide github/resume?

This forces users to sign in with My MLH, so we'll need to kill off the existing test signups before going live.

Also fixed the edit form to pull the correct values and added a missing Gem.
